### PR TITLE
Fix for Power Menu Rounding

### DIFF
--- a/Round/shared.css
+++ b/Round/shared.css
@@ -280,7 +280,9 @@ div.basiccontextmenu_contextMenuContents_TBSbv {
 .basiccontextmenu_contextMenuContents_TBSbv
   .Play.basiccontextmenu_contextMenuItem_3PqLg:nth-child(1),
 .basiccontextmenu_contextMenuContents_TBSbv
-  .Install.basiccontextmenu_contextMenuItem_3PqLg:nth-child(1) {
+  .Install.basiccontextmenu_contextMenuItem_3PqLg:nth-child(1),
+.basiccontextmenu_contextMenuContents_TBSbv 
+  .basiccontextmenu_contextMenuItem_3PqLg:nth-last-child(5):nth-child(5)[tone="destructive"] {
   border-radius: 20px 20px 0px 0px;
 }
 
@@ -291,9 +293,13 @@ div.basiccontextmenu_contextMenuContents_TBSbv {
   .Install 
   ~ .basiccontextmenu_contextMenuItem_3PqLg:nth-last-child(5),
 .basiccontextmenu_contextMenuContents_TBSbv 
-  .basiccontextmenu_contextMenuItem_3PqLg:nth-last-child(5):nth-child(5),
+  .basiccontextmenu_contextMenuItem_3PqLg:nth-last-child(5):nth-child(5):not([tone="destructive"]),
 .basiccontextmenu_contextMenuContents_TBSbv 
-  .basiccontextmenu_contextMenuItem_3PqLg:nth-last-child(5):nth-child(4) {
+  .basiccontextmenu_contextMenuItem_3PqLg:nth-last-child(5):nth-child(4),
+.basiccontextmenu_contextMenuContents_TBSbv
+  .basiccontextmenu_contextMenuItem_3PqLg:nth-last-child(7):nth-child(3)[tone="destructive"],
+.basiccontextmenu_contextMenuContents_TBSbv
+  .basiccontextmenu_contextMenuItem_3PqLg:nth-last-child(3):nth-child(7)[tone="destructive"] {
   border-radius: 0px 0px 20px 20px;
 }
 

--- a/Round/theme.json
+++ b/Round/theme.json
@@ -2,7 +2,7 @@
   "name": "Round",
   "author": "EMERALD#0874",
   "target": "System-Wide",
-  "version": "v1.4",
+  "version": "v1.5",
   "inject": {
     "shared.css": ["SP", "MainMenu", "QuickAccess"]
   },


### PR DESCRIPTION
I found this bug:
![image](https://user-images.githubusercontent.com/31255827/181996058-da848417-7f04-4d69-b311-8c746547473b.png)

Now it looks like this (I verified that all other menus are still correct): 
![image](https://user-images.githubusercontent.com/31255827/181996079-733bd469-69e2-440e-9253-d287401a257c.png)

---
The fix with this one was using the fact that the `[tone="destructive"]` was set on all power menu options. I have not found this tone used anywhere else in this menu style.