### PR TITLE
Round fixes for downloads and control scheme pages

### DIFF
--- a/Galactic/round-outline.css
+++ b/Galactic/round-outline.css
@@ -80,6 +80,15 @@
   > .appactivityday_EventBody_NEMXh
   > .Panel
   > .focusring_FocusRingRoot_3PH_X
+  > .focusring_FocusRing_1IZrQ,
+.controllerconfiguratorchoosebinding_ChooseBindingContainer_1Kj9l
+  > .gamepadtabbedpage_GamepadTabbedPage_3IBLc
+  > .gamepadtabbedpage_TabContents_WDa0_
+  > .overlappingtransition_TransitionGroup_11Twu
+  > .overlappingtransition_ContentWrapper_1knAs
+  > .Panel
+  > .gamepadtabbedpage_TabContentsScroll_1X4dt
+  > .focusring_FocusRingRoot_3PH_X
   > .focusring_FocusRing_1IZrQ {
   border: none;
   outline: 2px solid rgba(255, 255, 255, 0.6);

--- a/Galactic/round.css
+++ b/Galactic/round.css
@@ -243,6 +243,18 @@ div.basiccontextmenu_contextMenuContents_TBSbv {
 .downloads_RemoveAllButton_1GdR5 {
   border-radius: var(--round-radius-size);
 }
+.downloads_Active_IbePL
+  > .downloads_SectionList_OINnO
+  > .downloads_SectionItemWrapper_21P7c
+  > .downloads_SectionItem_1VNuY {
+  border-radius: 0px !important;
+}
+.downloadgraph_HeroContainer_3WauY > .libraryassetimage_GreyBackground_2E7G8,
+.downloadgraph_HeroContainer_3WauY
+  > .libraryassetimage_GreyBackground_2E7G8
+  > .libraryassetimage_Image_24_Au {
+  border-radius: 0px !important;
+}
 
 /* Mods */
 .CssLoader_ThemeBrowser_SingleItem_BgImage,

--- a/Galactic/theme.json
+++ b/Galactic/theme.json
@@ -2,7 +2,7 @@
   "name": "Galactic",
   "author": "EMERALD#0874",
   "target": "System-Wide",
-  "version": "v1.6",
+  "version": "v1.7",
   "inject": {
     "background.css": ["SP"]
   },

--- a/Round/round-outline.css
+++ b/Round/round-outline.css
@@ -80,6 +80,15 @@
   > .appactivityday_EventBody_NEMXh
   > .Panel
   > .focusring_FocusRingRoot_3PH_X
+  > .focusring_FocusRing_1IZrQ,
+.controllerconfiguratorchoosebinding_ChooseBindingContainer_1Kj9l
+  > .gamepadtabbedpage_GamepadTabbedPage_3IBLc
+  > .gamepadtabbedpage_TabContents_WDa0_
+  > .overlappingtransition_TransitionGroup_11Twu
+  > .overlappingtransition_ContentWrapper_1knAs
+  > .Panel
+  > .gamepadtabbedpage_TabContentsScroll_1X4dt
+  > .focusring_FocusRingRoot_3PH_X
   > .focusring_FocusRing_1IZrQ {
   border: none;
   outline: 2px solid rgba(255, 255, 255, 0.6);

--- a/Round/shared.css
+++ b/Round/shared.css
@@ -243,6 +243,18 @@ div.basiccontextmenu_contextMenuContents_TBSbv {
 .downloads_RemoveAllButton_1GdR5 {
   border-radius: var(--round-radius-size);
 }
+.downloads_Active_IbePL
+  > .downloads_SectionList_OINnO
+  > .downloads_SectionItemWrapper_21P7c
+  > .downloads_SectionItem_1VNuY {
+  border-radius: 0px !important;
+}
+.downloadgraph_HeroContainer_3WauY > .libraryassetimage_GreyBackground_2E7G8,
+.downloadgraph_HeroContainer_3WauY
+  > .libraryassetimage_GreyBackground_2E7G8
+  > .libraryassetimage_Image_24_Au {
+  border-radius: 0px !important;
+}
 
 /* Mods */
 .CssLoader_ThemeBrowser_SingleItem_BgImage,

--- a/Round/theme.json
+++ b/Round/theme.json
@@ -2,7 +2,7 @@
   "name": "Round",
   "author": "EMERALD#0874",
   "target": "System-Wide",
-  "version": "v2.0",
+  "version": "v2.1",
   "inject": {
     "shared.css": ["SP", "MainMenu", "QuickAccess"]
   },


### PR DESCRIPTION
Fixes incorrect rounding in downloads screen and focus ring appearing round around square elements in Steam Input configuration. Closes #22 and #14.