### PR TITLE
Improve Switch-Like Home compatibility and support news

### DIFF
--- a/Galactic/round-outline.css
+++ b/Galactic/round-outline.css
@@ -105,8 +105,3 @@
     focusring_fadeOutline_2hZu3 0.4s ease,
     focusring_blinker_3wFMM 1.2s ease-in-out 0.4s 20;
 }
-
-/* fix for other themes */
-.gamepadhomerecentgames_RecentGamesContainer_2_cRk {
-  padding-top: 62px;
-}

--- a/Galactic/round-outline.css
+++ b/Galactic/round-outline.css
@@ -18,6 +18,12 @@
 
 @keyframes appportrait_growOutline_3wk3d {
   0% {
+    /* This is necessary to fix themes like Switch-Like Home that rely on recent game sizes */
+    border: 2px solid;
+    margin: -2px;
+    border-radius: calc(var(--round-radius-size) + 2px);
+  }
+  0.1% {
     border: 12px solid;
     margin: -12px;
     border-radius: calc(var(--round-radius-size) + 10px);

--- a/Galactic/round-outline.css
+++ b/Galactic/round-outline.css
@@ -9,6 +9,13 @@
   margin: -2px;
 }
 
+.gpfocus .basicpartnereventspage_BasicPartnerEvent_2yuwU {
+  outline: none;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  border-radius: calc(var(--round-radius-size) + 2px);
+  margin: 54px auto 14px auto;
+}
+
 @keyframes appportrait_growOutline_3wk3d {
   0% {
     border: 12px solid;

--- a/Galactic/round-outline.css
+++ b/Galactic/round-outline.css
@@ -98,3 +98,8 @@
     focusring_fadeOutline_2hZu3 0.4s ease,
     focusring_blinker_3wFMM 1.2s ease-in-out 0.4s 20;
 }
+
+/* fix for other themes */
+.gamepadhomerecentgames_RecentGamesContainer_2_cRk {
+  padding-top: 62px;
+}

--- a/Galactic/round.css
+++ b/Galactic/round.css
@@ -100,6 +100,19 @@ div.basiccontextmenu_contextMenuContents_TBSbv {
   border-radius: var(--round-radius-size);
   overflow: hidden;
 }
+/* News articles */
+.apppartnereventspage_PartnerEvent_lwprN {
+  border-radius: var(--round-radius-size) !important;
+  overflow: hidden;
+}
+.partnereventshared_Button_3P0Tm.partnereventshared_Icon_3p1Hj {
+  border-radius: var(--round-radius-size) !important;
+}
+.discussionwidget_VoteContainer_1uhQY,
+.discussionwidget_DiscussContainer_3tXYJ,
+.discussionwidget_ShareContainer_cLK_F {
+  border-radius: var(--round-radius-size) !important;
+}
 
 /* Trending among friends (annoying to mess with outlines with, sorry if this is confusing lol) */
 .gamecapsule_GameCapsule_fXdhj .gamecapsule_BottomBar_3-GyQ {

--- a/Round/round-outline.css
+++ b/Round/round-outline.css
@@ -105,8 +105,3 @@
     focusring_fadeOutline_2hZu3 0.4s ease,
     focusring_blinker_3wFMM 1.2s ease-in-out 0.4s 20;
 }
-
-/* fix for other themes */
-.gamepadhomerecentgames_RecentGamesContainer_2_cRk {
-  padding-top: 62px;
-}

--- a/Round/round-outline.css
+++ b/Round/round-outline.css
@@ -18,6 +18,12 @@
 
 @keyframes appportrait_growOutline_3wk3d {
   0% {
+    /* This is necessary to fix themes like Switch-Like Home that rely on recent game sizes */
+    border: 2px solid;
+    margin: -2px;
+    border-radius: calc(var(--round-radius-size) + 2px);
+  }
+  0.1% {
     border: 12px solid;
     margin: -12px;
     border-radius: calc(var(--round-radius-size) + 10px);

--- a/Round/round-outline.css
+++ b/Round/round-outline.css
@@ -9,6 +9,13 @@
   margin: -2px;
 }
 
+.gpfocus .basicpartnereventspage_BasicPartnerEvent_2yuwU {
+  outline: none;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  border-radius: calc(var(--round-radius-size) + 2px);
+  margin: 54px auto 14px auto;
+}
+
 @keyframes appportrait_growOutline_3wk3d {
   0% {
     border: 12px solid;

--- a/Round/round-outline.css
+++ b/Round/round-outline.css
@@ -98,3 +98,8 @@
     focusring_fadeOutline_2hZu3 0.4s ease,
     focusring_blinker_3wFMM 1.2s ease-in-out 0.4s 20;
 }
+
+/* fix for other themes */
+.gamepadhomerecentgames_RecentGamesContainer_2_cRk {
+  padding-top: 62px;
+}

--- a/Round/shared.css
+++ b/Round/shared.css
@@ -100,6 +100,19 @@ div.basiccontextmenu_contextMenuContents_TBSbv {
   border-radius: var(--round-radius-size);
   overflow: hidden;
 }
+/* News articles */
+.apppartnereventspage_PartnerEvent_lwprN {
+  border-radius: var(--round-radius-size) !important;
+  overflow: hidden;
+}
+.partnereventshared_Button_3P0Tm.partnereventshared_Icon_3p1Hj {
+  border-radius: var(--round-radius-size) !important;
+}
+.discussionwidget_VoteContainer_1uhQY,
+.discussionwidget_DiscussContainer_3tXYJ,
+.discussionwidget_ShareContainer_cLK_F {
+  border-radius: var(--round-radius-size) !important;
+}
 
 /* Trending among friends (annoying to mess with outlines with, sorry if this is confusing lol) */
 .gamecapsule_GameCapsule_fXdhj .gamecapsule_BottomBar_3-GyQ {


### PR DESCRIPTION
This fixes a bug when using Switch-Like Home with Round and adds rounding to the news pop-ups.

Closes #15.