### PR TITLE
Add support for disabling skinning of lock screen

### DIFF
--- a/Obsidian/lockscreen.css
+++ b/Obsidian/lockscreen.css
@@ -1,0 +1,4 @@
+/* Lock screen */
+.lockscreen_Container_3rFFU {
+    background: var(--obsidian-main-color) !important;
+}

--- a/Obsidian/shared.css
+++ b/Obsidian/shared.css
@@ -226,7 +226,3 @@ OTHER
 .gamepaddialog_ModalPosition_30VHl > .gamepaddialog_GamepadDialogContent_3joNk {
   background: var(--obsidian-main-color) !important;
 }
-/* Lock screen */
-.lockscreen_Container_3rFFU {
-  background: var(--obsidian-main-color) !important;
-}

--- a/Obsidian/theme.json
+++ b/Obsidian/theme.json
@@ -42,6 +42,20 @@
           "violet.css": ["SP", "MainMenu", "QuickAccess"]
         }
       }
+    },
+    "Apply on lock screen": {
+			"type": "checkbox",
+			"default": "Yes",
+			"values": {
+				"No": {},
+				"Yes": {
+					"lockscreen.css": [
+						"SP",
+						"MainMenu",
+						"QuickAccess"
+					]
+				}
+			}
     }
   }
 }


### PR DESCRIPTION
Added a toggle to disable the skinning of the lock screen to enable support for custom images in from the plugin Minimal Lock Screen. This is a pull request for the solution i found in issue #52 