### PR TITLE
Obsidian/shared.css: Theming more components

### DIFF
--- a/Obsidian/shared.css
+++ b/Obsidian/shared.css
@@ -210,6 +210,14 @@ QUICK ACCESS
 OTHER
 */
 
+/* Context menu buttons */
+/* Don't set !important as it's break button highlight color */
+.gamepadcontextmenu_contextMenuItem_1sdvo{
+  background: var(--obsidian-main-color); 
+}
+.gamepadcontextmenu_contextMenuItem_1sdvo.Stream,.gamepadcontextmenu_contextMenuItem_1sdvo.Connect,.gamepadcontextmenu_contextMenuItem_1sdvo.Launch,.gamepadcontextmenu_contextMenuItem_1sdvo.PlayMusic,.gamepadcontextmenu_contextMenuItem_1sdvo.Play,.gamepadcontextmenu_contextMenuItem_1sdvo.Resume,.gamepadcontextmenu_contextMenuItem_1sdvo.BorrowApp,.gamepadcontextmenu_contextMenuItem_1sdvo.Download,.gamepadcontextmenu_contextMenuItem_1sdvo.Update,.gamepadcontextmenu_contextMenuItem_1sdvo.PreLoad,.gamepadcontextmenu_contextMenuItem_1sdvo.Install,.gamepadcontextmenu_contextMenuItem_1sdvo.Pause,.gamepadcontextmenu_contextMenuItem_1sdvo.Stop,.gamepadcontextmenu_contextMenuItem_1sdvo.Cancel{
+  background: var(--obsidian-main-color);
+}
 /* Navigation */
 .mainmenu_Menu_23IDi {
   background: var(--obsidian-main-color) !important;
@@ -222,8 +230,28 @@ OTHER
 .gamepadsearch_GamepadSearch_P_AlE {
   background: var(--obsidian-main-color) !important;
 }
+/* Volume panel */
+/* Don't set !important as it's not required */
+.audio_VolumePopin_2iUUM {
+  background: var(--obsidian-main-color);
+}
+.gamepadslider_SliderTrack_Mq25N {
+  background: #23262e;
+}
 /* Media upload */
 .gamepaddialog_ModalPosition_30VHl > .gamepaddialog_GamepadDialogContent_3joNk {
+  background: var(--obsidian-main-color) !important;
+}
+/* Notification */
+.notificationcontent_ShortTemplate_2w-Eq, .notificationcontent_PinnedTemplate_H_NPi, .notificationcontent_StandardTemplate_1B_uv, .notificationcontent_ShortTemplate_nwer8, .notificationcontent_StandardTemplate_5HZT7, .notificationcontent_PinnedTemplateDesktop_1-8YO, .notificationcontent_PinnedTemplate_1X-O1 {
+  background: var(--obsidian-main-color) !important;
+}
+/* Tabbed Page Contents */
+.gamepadtabbedpage_TabContents_WDa0_ {
+  background: var(--obsidian-main-color) !important;
+}
+/* Loading Screen */
+.loadingthrobber_Container_3sa1N, .loadingthrobber_Container_3sa1N.loadingthrobber_PreloadThrobber_1-epa {
   background: var(--obsidian-main-color) !important;
 }
 /* Lock screen */

--- a/Obsidian/theme.json
+++ b/Obsidian/theme.json
@@ -5,7 +5,7 @@
   "version": "v3.0",
   "manifest_version": 6,
   "inject": {
-    "shared.css": ["SP", "MainMenu", "QuickAccess"]
+    "shared.css": ["SP", "MainMenu", "QuickAccess", "notificationtoasts.*"]
   },
   "target": "System-Wide",
   "patches": {
@@ -15,31 +15,31 @@
       "values": {
         "Black": {},
         "Dark Gray": {
-          "dark-gray.css": ["SP", "MainMenu", "QuickAccess"]
+          "dark-gray.css": ["SP", "MainMenu", "QuickAccess", "notificationtoasts.*"]
         },
         "Gray": {
-          "gray.css": ["SP", "MainMenu", "QuickAccess"]
+          "gray.css": ["SP", "MainMenu", "QuickAccess", "notificationtoasts.*"]
         },
         "Red": {
-          "red.css": ["SP", "MainMenu", "QuickAccess"]
+          "red.css": ["SP", "MainMenu", "QuickAccess", "notificationtoasts.*"]
         },
         "Orange": {
-          "orange.css": ["SP", "MainMenu", "QuickAccess"]
+          "orange.css": ["SP", "MainMenu", "QuickAccess", "notificationtoasts.*"]
         },
         "Yellow": {
-          "yellow.css": ["SP", "MainMenu", "QuickAccess"]
+          "yellow.css": ["SP", "MainMenu", "QuickAccess", "notificationtoasts.*"]
         },
         "Green": {
-          "green.css": ["SP", "MainMenu", "QuickAccess"]
+          "green.css": ["SP", "MainMenu", "QuickAccess", "notificationtoasts.*"]
         },
         "Blue": {
-          "blue.css": ["SP", "MainMenu", "QuickAccess"]
+          "blue.css": ["SP", "MainMenu", "QuickAccess", "notificationtoasts.*"]
         },
         "Indigo": {
-          "indigo.css": ["SP", "MainMenu", "QuickAccess"]
+          "indigo.css": ["SP", "MainMenu", "QuickAccess", "notificationtoasts.*"]
         },
         "Violet": {
-          "violet.css": ["SP", "MainMenu", "QuickAccess"]
+          "violet.css": ["SP", "MainMenu", "QuickAccess", "notificationtoasts.*"]
         },
         "Custom": {}
       },

--- a/Obsidian/theme.json
+++ b/Obsidian/theme.json
@@ -2,7 +2,7 @@
   "name": "Obsidian",
   "description": "This theme is based off of pure black themes commonly created for AMOLED devices. Although the Steam Deck has an LCD screen, I find the darker colors easier on my eyes and less Steam-themed. There are also options for dark gray, gray, and dark variants of all colors of the rainbow.",
   "author": "EMERALD#0874",
-  "version": "v3.0",
+  "version": "v3.1",
   "manifest_version": 6,
   "inject": {
     "shared.css": ["SP", "MainMenu", "QuickAccess", "notificationtoasts.*"]


### PR DESCRIPTION
This commit including support of following components' background:
* Context menu buttons
* Volume panel
* Notification
* Tabbed Page Contents
* Loading Screen