### PR TITLE
fix: add roundness to the settings radio menu

### DIFF
--- a/Round/shared.css
+++ b/Round/shared.css
@@ -369,6 +369,18 @@ button.appdetailsactivitysection_FetchMoreContainer_39Zur.DialogButton.gamepaddi
   margin-top: 0px !important;
 }
 
+.radio_Active_3ZBFo {
+  border-radius: var(--round-radius-size);
+}
+
+.RadioButton {
+  border-radius: var(--round-radius-size);
+}
+
+.radio_Group_2qYC3 {
+  border-radius: var(--round-radius-size);
+}
+
 /* Options Container  */
 /* 
   The majority of styles in this section were removed due to each container 

--- a/Round/theme.json
+++ b/Round/theme.json
@@ -3,7 +3,7 @@
   "description": "This theme adds round edges to any image that can reasonably have them. Certain images like achievements, trading cards, and profile pictures have been left as-is to avoid removing any detail. Anything largely rectangular or difficult to round (ex. sets of buttons, chat, header) has also been left as-is.",
   "author": "EMERALD#0874",
   "target": "System-Wide",
-  "version": "v2.5",
+  "version": "v2.6",
   "manifest_version": 2,
   "inject": {
     "shared.css": ["SP", "MainMenu", "QuickAccess"]


### PR DESCRIPTION
This pr fixes the radio menu on the settings page, on "Friends & Chat"

Before:

![before](https://github.com/EMERALD0874/Steam-Deck-Themes/assets/75721601/348ba172-7c2a-44de-ae6d-1abd8edf0115)

After:
![after](https://github.com/EMERALD0874/Steam-Deck-Themes/assets/75721601/39016264-d26d-4d00-a9c1-057f7b08bffd)
