### PR TITLE
Fixed in game QAM header background

### DIFF
--- a/Obsidian/shared.css
+++ b/Obsidian/shared.css
@@ -211,6 +211,10 @@ QUICK ACCESS
   background-color: var(--obsidian-main-color);
 }
 
+.header_Header_1E_SL.header_InQuickAccess_2mRo5{
+  background-color: var(--obsidian-main-color);
+}
+
 /*
 OTHER
 */


### PR DESCRIPTION
`.header_Header_1E_SL.header_InQuickAccess_2mRo5` was overwriting `background-color`.  This patch targets that element and set's its background color properly.

This addresses #73 