### PR TITLE
Centered-Home - Expand when in Docked Mode

### DIFF
--- a/Centered-Home/docked.css
+++ b/Centered-Home/docked.css
@@ -4,12 +4,13 @@
   }
 
   .gamepadhomerecentgames_RecentGamesContainer_2_cRk {
-    padding-top: 200px !important;
+    padding: 0 !important;
     height: 100%;
+    display: flex;
   }
 
-  /* prevent that blur behind the selected game is cut off */
-  .basicgamecarousel_CarouselCapsuleBackgroundGlow_1H3Kf {
-    bottom: 55px;
+  .gamepadhomerecentgames_RecentGamesInnerContainer_282X0 {
+    flex: 1;
+    margin: auto;
   }
 }

--- a/Centered-Home/docked.css
+++ b/Centered-Home/docked.css
@@ -1,0 +1,15 @@
+@media all and (min-width: 1300px) {
+  .gamepadhome_RecentSection_39tNv {
+    height: 100%;
+  }
+
+  .gamepadhomerecentgames_RecentGamesContainer_2_cRk {
+    padding-top: 200px !important;
+    height: 100%;
+  }
+
+  /* prevent that blur behind the selected game is cut off */
+  .basicgamecarousel_CarouselCapsuleBackgroundGlow_1H3Kf {
+    bottom: 55px;
+  }
+}

--- a/Centered-Home/shared.css
+++ b/Centered-Home/shared.css
@@ -1,6 +1,10 @@
-.basicgamecarousel_BasicGameCarousel_3MdH5 {
-  height: 320px !important;
+@media all and (max-width: 1200px) {
+  /* wont be apply in handheld mode as it cuts off the background blur*/
+  .basicgamecarousel_BasicGameCarousel_3MdH5 {
+    height: 320px !important;
+  }
 }
+
 .gamepadhomerecentgames_RecentGamesContainer_2_cRk {
   padding-top: 98px;
   padding-bottom: 61px;

--- a/Centered-Home/shared.css
+++ b/Centered-Home/shared.css
@@ -1,5 +1,5 @@
 @media all and (max-width: 1200px) {
-  /* wont be apply in handheld mode as it cuts off the background blur*/
+  /* wont be applied in docked mode as it cuts off the background blur*/
   .basicgamecarousel_BasicGameCarousel_3MdH5 {
     height: 320px !important;
   }

--- a/Centered-Home/theme.json
+++ b/Centered-Home/theme.json
@@ -32,11 +32,7 @@
       "type": "checkbox",
       "values": {
         "No": {},
-        "Yes": {
-          "docked.css": [
-            "SP"
-          ]
-        }
+        "Yes": { "docked.css": ["SP"] }
       }
     }
   }

--- a/Centered-Home/theme.json
+++ b/Centered-Home/theme.json
@@ -26,6 +26,18 @@
         "No": {},
         "Yes": { "force-header.css": ["SP"] }
       }
+    },
+    "Expand when docked": {
+      "default": "Yes",
+      "type": "checkbox",
+      "values": {
+        "No": {},
+        "Yes": {
+          "docked.css": [
+            "SP"
+          ]
+        }
+      }
     }
   }
 }

--- a/Centered-Home/theme.json
+++ b/Centered-Home/theme.json
@@ -3,7 +3,7 @@
   "description": "This theme makes the recent games section take up the full screen and centers it vertically. Options are provided for hiding and showing the header as well as whether or not to consider the title of the game when centering vertically (assuming the header is hidden). I recommend using this with the Static Background theme by SuchMeme pictured here.",
   "author": "EMERALD#0874",
   "target": "Home",
-  "version": "v1.1",
+  "version": "v1.2",
   "manifest_version": 2,
   "inject": { "shared.css": ["SP"] },
   "patches": {
@@ -27,7 +27,7 @@
         "Yes": { "force-header.css": ["SP"] }
       }
     },
-    "Expand when docked": {
+    "Expand When Docked": {
       "default": "Yes",
       "type": "checkbox",
       "values": {


### PR DESCRIPTION
Fixes #23.
The centering is done automatically with Flexbox, so no math needed and should work with every resolution/scaling.
Also adds a toggle so the expansion can be opt-out if wanted (this doesn't affect the expansion/centering in handheld mode).

I attached some screenshots with different scaling settings applied.Please note that i tested this on 1080p only, as i do not own a 4K Monitor.

Before
![before](https://github.com/EMERALD0874/Steam-Deck-Themes/assets/74593687/56c01c31-92e3-43cf-9e43-6b2e37b338ea)

Normal Scaling
![normal](https://github.com/EMERALD0874/Steam-Deck-Themes/assets/74593687/a433e394-9381-46d6-a7b5-7b9686467951)

Minimal Scaling
![min_scale](https://github.com/EMERALD0874/Steam-Deck-Themes/assets/74593687/656e2d7a-c4fe-447c-a5a9-dd932d6db2bc)

Maximal Scaling
![max_scale](https://github.com/EMERALD0874/Steam-Deck-Themes/assets/74593687/d5a66c80-07b9-4949-bdf6-385581dfa5ee)