### PR TITLE
Show Footer Categories

### DIFF
--- a/Centered-Home/show-footer-categories.css
+++ b/Centered-Home/show-footer-categories.css
@@ -1,0 +1,7 @@
+.gamepadhomerecentgames_RecentGamesContainer_2_cRk {
+    padding-top: 98px;
+}
+
+.gamepadhome_RecentSection_39tNv {
+    height: 86%;
+}

--- a/Centered-Home/theme.json
+++ b/Centered-Home/theme.json
@@ -34,6 +34,14 @@
         "No": {},
         "Yes": { "docked.css": ["SP"] }
       }
+    },
+    "Show Footer Categories": {
+      "default": "No",
+      "type": "checkbox",
+      "values": {
+        "No": {},
+        "Yes": {"show-footer-categories": ["SP"]}
+      }
     }
   }
 }

--- a/Centered-Home/theme.json
+++ b/Centered-Home/theme.json
@@ -40,7 +40,7 @@
       "type": "checkbox",
       "values": {
         "No": {},
-        "Yes": {"show-footer-categories.css": ["SP"]}
+        "Yes": { "show-footer-categories.css": ["SP"] }
       }
     }
   }

--- a/Centered-Home/theme.json
+++ b/Centered-Home/theme.json
@@ -40,7 +40,7 @@
       "type": "checkbox",
       "values": {
         "No": {},
-        "Yes": {"show-footer-categories": ["SP"]}
+        "Yes": {"show-footer-categories.css": ["SP"]}
       }
     }
   }

--- a/Centered-Home/theme.json
+++ b/Centered-Home/theme.json
@@ -3,7 +3,7 @@
   "description": "This theme makes the recent games section take up the full screen and centers it vertically. Options are provided for hiding and showing the header as well as whether or not to consider the title of the game when centering vertically (assuming the header is hidden). I recommend using this with the Static Background theme by SuchMeme pictured here.",
   "author": "EMERALD#0874",
   "target": "Home",
-  "version": "v1.2",
+  "version": "v1.3",
   "manifest_version": 2,
   "inject": { "shared.css": ["SP"] },
   "patches": {


### PR DESCRIPTION
Adds an option to show the footer categories (without showing the content itself), as follows:

![download](https://github.com/EMERALD0874/Steam-Deck-Themes/assets/18127936/e63e03e1-1b0d-46aa-b92a-4c6a3cd5d0e5)

This shouldn't affect anything else about the theme, and was a small tweak I wanted because I wanted to know A) How many friends I had on and B) The home felt a bit empty to me without it.

Thank ya for the main theme itself :)